### PR TITLE
Fix object literal spread errors in MS Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,9 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+  "browserslist": [
+    "last 1 chrome version",
+    "last 1 firefox version",
+    "last 1 safari version"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "browserslist": [
     ">0.2%",
     "not dead",
-    "not op_mini all"
+    "not op_mini all",
+    "not ie <= 11"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "extends": "react-app"
   },
   "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version"
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^7.2.1",
     "bootstrap": "^4.5.0",
     "react": "^16.13.1",
+    "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "reactstrap": "^8.4.1",

--- a/src/hooks/useSocket.js
+++ b/src/hooks/useSocket.js
@@ -6,7 +6,7 @@ const useSocket = (url, options) => {
     const [isConnecting, setIsConnecting] = useState(true);
 
     const { current: socket } = useRef(
-        io(url, {...options, autoConnect: false})
+        io(url, { ...options, autoConnect: false })
     );
 
     useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import 'react-app-polyfill/ie11';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';


### PR DESCRIPTION
~~Without the space after `false` here, the app crashes in Edge with an error: "SCRIPT1028: Expected identifier, string or number"~~

Old Microsoft Edge doesn't support spread in object literals. Use react-app-polyfill to fix that. 