### PR TITLE
Use environment variable for back-end websocket URL

### DIFF
--- a/src/components/SocketManager.js
+++ b/src/components/SocketManager.js
@@ -4,7 +4,7 @@ import Main from "./Main";
 import useSocket from "../hooks/useSocket";
 
 function SocketManager() {
-    const [socket, isConnected, isConnecting] = useSocket("ws://localhost:3001");
+    const [socket, isConnected, isConnecting] = useSocket(process.env.REACT_APP_BACKEND_URL);
 
     const [roomName, setRoomName] = useState("");
     const [boardState, setBoardState] = useState(null);


### PR DESCRIPTION
- Add `REACT_APP_BACKEND_URL` environment variable to connect to back-end websocket

To run this, you'll need to add a file called `.env` to your local project root which contains
```
REACT_APP_BACKEND_URL="ws://localhost:3001"
```
or wherever you have the back-end running.