### PR TITLE
Fix warning for Pip SVG: transform="none" invalid value

### DIFF
--- a/src/components/BoardUI/Pip.js
+++ b/src/components/BoardUI/Pip.js
@@ -21,7 +21,7 @@ function Pip({ size, top, bot, posX, invertY, onClick, active }) {
                 height="600"
                 x={posX}
                 y={invertY ? "-100%" : "0"}
-                transform={invertY ? "scale(1, -1)" : "none"}
+                transform={invertY ? "scale(1, -1)" : ""}
             />
 
             {checkers.map((checker, i) => {


### PR DESCRIPTION
Just a little SVG mistake I had made that was causing warnings in the browser console.