### PR TITLE
fixup! Change Board properties to objects to match backend (#32)

### DIFF
--- a/src/components/BoardUI/BackgammonExtras.js
+++ b/src/components/BoardUI/BackgammonExtras.js
@@ -15,9 +15,11 @@ function BackgammonExtras({
                 {player ? `Playing as ${Player.properties[player].colorName}` : "Spectating"}
             </ListGroupItem>
             <ListGroupItem>
-                {winner
+                {winner !== null
                     ? `${Player.properties[winner].colorName} won!`
-                    : `${Player.properties[turn].colorName}’s turn`}
+                    : turn !== null
+                    ? `${Player.properties[turn].colorName}’s turn`
+                    : null}
             </ListGroupItem>
             <ListGroupItem>
                 <Dice initialDice={diceRolled} remainingDice={dice} />


### PR DESCRIPTION
Display winner correctly when there is a draw.
Don't display who's turn it is before the game starts.