### PR TITLE
Fix animation for undoing turns in Safari and Edge

### DIFF
--- a/src/components/BoardUI/CheckerStack.js
+++ b/src/components/BoardUI/CheckerStack.js
@@ -79,7 +79,9 @@ function CheckerStack({ size, top, bot, reverse, pipNum, recentMove, isSource })
                 <animated.div
                     key={key}
                     style={props}
-                    ref={(el) => (domRefs[pipNum][item.color] = el)}>
+                    ref={(el) => {
+                        if (i === checkers.length - 1) domRefs[pipNum][item.color] = el;
+                    }}>
                     <Checker color={item.color} glow={isSource && i === checkers.length - 1} />
                 </animated.div>
             ))}


### PR DESCRIPTION
Making the top checker ref conditional on actually _being_ the top checker fixes a race condition in Safari and Edge for undoing turns where multiple checkers return from the same pip.